### PR TITLE
Allows identity_op in `From` implementations.

### DIFF
--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -376,6 +376,7 @@ impl BitfieldStruct {
                 ReprKind::U128 => quote! { IsU128Compatible },
             };
             quote_spanned!(span=>
+                #[allow(clippy::identity_op)]
                 impl ::core::convert::From<#prim> for #ident
                 where
                     [(); #actual_bits]: ::modular_bitfield::private::#trait_check_ident,
@@ -386,6 +387,7 @@ impl BitfieldStruct {
                     }
                 }
 
+                #[allow(clippy::identity_op)]
                 impl ::core::convert::From<#ident> for #prim
                 where
                     [(); #actual_bits]: ::modular_bitfield::private::#trait_check_ident,


### PR DESCRIPTION
Clippy's `identity_op` warns about those operations that do not change the
meaning of an expression.

The `From` autogenerated implementations use the underlying expression for
calculating the size of the bitfield, which has a form `0usize + a_1 + a_2 + ...
+ a_n`.

The initial zero triggers the lint from clippy, but is being kept to simplify
the generation of the sum expression to avoid edge cases.

For this reason, instead of modifying the code to avoid the lint, an `allow`
attribute was added to the generated part of the code that triggered the lint.