### PR TITLE
Allow unneccesary_cast for the Specifier implementation.

### DIFF
--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -88,6 +88,7 @@ impl BitfieldStruct {
                     bytes: Self::Bytes,
                 ) -> ::core::result::Result<Self::InOut, ::modular_bitfield::error::InvalidBitPattern<Self::Bytes>>
                 {
+                    #[allow(clippy::unnecessary_cast)]
                     let __bf_max_value: Self::Bytes = (0x01 as Self::Bytes)
                         .checked_shl(Self::BITS as ::core::primitive::u32)
                         .unwrap_or(<Self::Bytes>::MAX);


### PR DESCRIPTION
When a bitfield struct is annotated with `derive(BitfieldSpecifier)`, the
`Specifier` trait is implemented for the type.

In the implementation of the trait, under `from_bytes`, a literal is cast to
`Self::Bytes`, which contains the type of the required integer representation.

The casting is identified as unnecessary by clippy, when expanded, but seems to
be necessary to avoid an ambiguous call.

For this reasons, `unnecessary_cast` was allowed in the code block where this happened.